### PR TITLE
Unconditionally add -pthread to googletest for Linux.

### DIFF
--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -15,6 +15,8 @@ include_directories(
 add_library(gmock STATIC
   ${gtest_vendor_BASE_DIR}/src/gtest-all.cc
   src/gmock-all.cc)
+set(THREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
+
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
 # detection logic into thinking no link libraries are necessary
@@ -22,10 +24,9 @@ add_library(gmock STATIC
 # for some additional information).  To work around that, we unconditionally
 # add the -pthread flag for Linux machines so it will always work
 if(UNIX AND NOT APPLE)
-  target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT} -pthread)
-else()
-  target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
+  list(APPEND THREAD_LIBS "-pthread")
 endif()
+target_link_libraries(gmock ${THREAD_LIBS})
 if(NOT WIN32)
   set_target_properties(gmock PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
 endif()

--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -3,8 +3,6 @@ cmake_minimum_required(VERSION 2.6.2)
 
 find_package(gtest_vendor REQUIRED)
 
-find_package(Threads)
-
 include_directories(
   include
   .  # to find the source files included with "src/gmock*.cc"
@@ -15,7 +13,6 @@ include_directories(
 add_library(gmock STATIC
   ${gtest_vendor_BASE_DIR}/src/gtest-all.cc
   src/gmock-all.cc)
-target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
@@ -26,6 +23,7 @@ target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
 if(UNIX AND NOT APPLE)
   target_link_libraries(gmock "-pthread")
 endif()
+
 if(NOT WIN32)
   set_target_properties(gmock PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
 endif()

--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -15,7 +15,7 @@ include_directories(
 add_library(gmock STATIC
   ${gtest_vendor_BASE_DIR}/src/gtest-all.cc
   src/gmock-all.cc)
-set(THREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
@@ -24,9 +24,8 @@ set(THREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
 # for some additional information).  To work around that, we unconditionally
 # add the -pthread flag for Linux machines so it will always work
 if(UNIX AND NOT APPLE)
-  list(APPEND THREAD_LIBS "-pthread")
+  target_link_libraries(gmock "-pthread")
 endif()
-target_link_libraries(gmock ${THREAD_LIBS})
 if(NOT WIN32)
   set_target_properties(gmock PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
 endif()

--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -15,7 +15,17 @@ include_directories(
 add_library(gmock STATIC
   ${gtest_vendor_BASE_DIR}/src/gtest-all.cc
   src/gmock-all.cc)
-target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
+# When building with asan (i.e. using colcon build --mixin asan-gcc),
+# asan itself provides a "fake" pthread that tricks the pthread
+# detection logic into thinking no link libraries are necessary
+# (see https://wiki.gentoo.org/wiki/AddressSanitizer/Problems#pthread_linking_issues
+# for some additional information).  To work around that, we unconditionally
+# add the -pthread flag for Linux machines so it will always work
+if(UNIX AND NOT APPLE)
+  target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT} -pthread)
+else()
+  target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
+endif()
 if(NOT WIN32)
   set_target_properties(gmock PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
 endif()

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -9,6 +9,8 @@ include_directories(
 )
 
 add_library(gtest STATIC src/gtest-all.cc)
+set(THREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
+
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
 # detection logic into thinking no link libraries are necessary
@@ -16,10 +18,10 @@ add_library(gtest STATIC src/gtest-all.cc)
 # for some additional information).  To work around that, we unconditionally
 # add the -pthread flag for Linux machines so it will always work
 if(UNIX AND NOT APPLE)
-  target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT} -pthread)
-else()
-  target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
+  list(APPEND THREAD_LIBS "-pthread")
 endif()
+target_link_libraries(gtest ${THREAD_LIBS})
+
 if(NOT WIN32)
   set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
 endif()

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -9,7 +9,7 @@ include_directories(
 )
 
 add_library(gtest STATIC src/gtest-all.cc)
-set(THREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
@@ -18,9 +18,8 @@ set(THREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
 # for some additional information).  To work around that, we unconditionally
 # add the -pthread flag for Linux machines so it will always work
 if(UNIX AND NOT APPLE)
-  list(APPEND THREAD_LIBS "-pthread")
+  target_link_libraries(gtest "-pthread")
 endif()
-target_link_libraries(gtest ${THREAD_LIBS})
 
 if(NOT WIN32)
   set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -9,7 +9,17 @@ include_directories(
 )
 
 add_library(gtest STATIC src/gtest-all.cc)
-target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
+# When building with asan (i.e. using colcon build --mixin asan-gcc),
+# asan itself provides a "fake" pthread that tricks the pthread
+# detection logic into thinking no link libraries are necessary
+# (see https://wiki.gentoo.org/wiki/AddressSanitizer/Problems#pthread_linking_issues
+# for some additional information).  To work around that, we unconditionally
+# add the -pthread flag for Linux machines so it will always work
+if(UNIX AND NOT APPLE)
+  target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT} -pthread)
+else()
+  target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
+endif()
 if(NOT WIN32)
   set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
 endif()

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -1,15 +1,12 @@
 project(gtest CXX C)
 cmake_minimum_required(VERSION 2.6.2)
 
-find_package(Threads)
-
 include_directories(
   include
   .  # to find the source files included with "src/gtest*.cc"
 )
 
 add_library(gtest STATIC src/gtest-all.cc)
-target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread


### PR DESCRIPTION
This ensures that we always link against pthread, even
when asan is in use.

Along with similar fixes in Fast-RTPS and osrf/osrf_testing_tools_cpp#21, this allows ros2 to build with the colcon `asan` mixin (as discussed in https://github.com/colcon/colcon-mixin-repository/pull/12)