### PR TITLE
1.8.9000

### DIFF
--- a/googlemock/package.xml
+++ b/googlemock/package.xml
@@ -2,7 +2,13 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gmock_vendor</name>
-  <version>1.8.0</version>
+  <!-- See googletest's package.xml for details about the versioning scheme. -->
+  <!--
+  Log of versions:
+
+  1.8.9000 = google/googletest@c6cb7e033591528a5fe2c63157a0d8ce927740dc + osrf commits
+  -->
+  <version>1.8.9000</version>
   <description>The package provides GoogleMock.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>

--- a/googletest/package.xml
+++ b/googletest/package.xml
@@ -2,7 +2,36 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gtest_vendor</name>
-  <version>1.8.0</version>
+  <!--
+  We add 900 to the patch part of the version and then multiply it by 10,
+  i.e. our version = `(upstream_patch_version + 900) * 10`,
+  so we can have intermediate releases as well as release any future official 1.8.x versions.
+
+  This is basically packing the patch part of the version and a fourth version part together
+  into the third part of the version.
+
+  The use of `900` instead of something else like `100` is arbitrary, but it might
+  help people recognize that this is a "special" version number.
+  It is needed however, because we cannot have a leading `0` in our patch version.
+
+  Consider these possible future versions as an example:
+
+  1.8.9000 -> current state of this repository, 1.8.0 + some commits from us and upstream
+  1.8.9010 -> upstream 1.8.1
+  1.8.9011 -> upstream 1.8.1 + additional commits from upstream or us
+  1.8.9012 -> upstream 1.8.1 + additional commits from 1.8.1011 + more new commits
+  1.8.9020 -> upstream 1.8.2
+  and so on...
+
+  This is planned to be temporary until we vendor package this, but for now
+  it will allow us to be flexible.
+  -->
+  <!--
+  Log of versions:
+
+  1.8.9000 = google/googletest@c6cb7e033591528a5fe2c63157a0d8ce927740dc + osrf commits
+  -->
+  <version>1.8.9000</version>
   <description>The package provides GoogleTest.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
I discussed this new versioning scheme with @dirk-thomas, but we think long term we should move to a new package which uses CMake's `ExternalProject` API to build and install these.

@nuclearsandwich FYI