### PR TITLE
Build with POSITION_INDEPENDENT_CODE

### DIFF
--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -26,6 +26,7 @@ endif()
 
 if(NOT WIN32)
   set_target_properties(gmock PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
+  set_target_properties(gmock PROPERTIES POSITION_INDEPENDENT_CODE True)
 endif()
 
 add_library(gmock_main STATIC src/gmock_main.cc)

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -20,6 +20,7 @@ endif()
 
 if(NOT WIN32)
   set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
+  set_target_properties(gtest PROPERTIES POSITION_INDEPENDENT_CODE True)
 endif()
 
 add_library(gtest_main STATIC src/gtest_main.cc)


### PR DESCRIPTION
This probably stems from a difference in the system linker scripts, but compiling packages against libgtest.a or libgmock.a can fail if they are built without -fPIC.

Should address build failures in consumers like this:
```
ld: gmock/libgmock.a(gtest-all.cc.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
ld: gmock/libgmock.a(gmock-all.cc.o): relocation R_X86_64_32 against `.bss' can not be used when making a shared object; recompile with -fPIC
ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
```

As a 'weird' bug with a 'weird' solution that could have unintended side effects, I triggered a pretty wide build to test this change:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13635)](http://ci.ros2.org/job/ci_linux/13635/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8515)](http://ci.ros2.org/job/ci_linux-aarch64/8515/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11349)](http://ci.ros2.org/job/ci_osx/11349/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13696)](http://ci.ros2.org/job/ci_windows/13696/)

The motivation for this change is to unblock building rviz_default_plugins for RHEL 7.

Docs on this property: https://cmake.org/cmake/help/latest/prop_tgt/POSITION_INDEPENDENT_CODE.html