### PR TITLE
use `target_compile_features()` to require C++11 features

### DIFF
--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -1,5 +1,5 @@
 project(gmock CXX C)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8)
 
 find_package(gtest_vendor REQUIRED)
 
@@ -13,6 +13,7 @@ include_directories(
 add_library(gmock STATIC
   ${gtest_vendor_BASE_DIR}/src/gtest-all.cc
   src/gmock-all.cc)
+target_compile_features(gmock PUBLIC cxx_std_11)  # Require C++11
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
@@ -30,3 +31,4 @@ if(NOT WIN32)
 endif()
 
 add_library(gmock_main STATIC src/gmock_main.cc)
+target_compile_features(gmock_main PUBLIC cxx_std_11)  # Require C++11

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -1,5 +1,5 @@
 project(gtest CXX C)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8)
 
 include_directories(
   include
@@ -7,6 +7,7 @@ include_directories(
 )
 
 add_library(gtest STATIC src/gtest-all.cc)
+target_compile_features(gtest PUBLIC cxx_std_11)  # Require C++11
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
@@ -24,3 +25,4 @@ if(NOT WIN32)
 endif()
 
 add_library(gtest_main STATIC src/gtest_main.cc)
+target_compile_features(gtest_main PUBLIC cxx_std_11)  # Require C++11


### PR DESCRIPTION
This is necessary for packages that don't globally set `CMAKE_CXX_STANDARD`.

CI OSX with change to `rclcpp` and this package [![Build Status](https://ci.ros2.org/job/ci_osx/11879/badge/icon)](https://ci.ros2.org/job/ci_osx/11879/)

@wjwwood does your local OSX workspace build successfully with this change?