### PR TITLE
Specify cmake as buildtool_depend

### DIFF
--- a/googlemock/package.xml
+++ b/googlemock/package.xml
@@ -19,7 +19,7 @@
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
-  <build_depend>cmake</build_depend>
+  <buildtool_depend>cmake</buildtool_depend>
 
   <build_export_depend>gtest_vendor</build_export_depend>
 

--- a/googletest/package.xml
+++ b/googletest/package.xml
@@ -42,7 +42,7 @@
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
-  <build_depend>cmake</build_depend>
+  <buildtool_depend>cmake</buildtool_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
CMake should be a buildtool_depend instead of a build_depend. This is important when cross-compiling.