### PR TITLE
Update CMakeLists.txt.upstream

### DIFF
--- a/CMakeLists.txt.upstream
+++ b/CMakeLists.txt.upstream
@@ -1,7 +1,7 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
@@ -9,12 +9,6 @@ endif (POLICY CMP0048)
 
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.11.0)
-
-if (CMAKE_VERSION VERSION_GREATER "3.0.2")
-  if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-  endif()
-endif()
 
 enable_testing()
 


### PR DESCRIPTION
Cmake <3.5 are deprecated.

https://gitlab.kitware.com/cmake/cmake/-/issues/25196