### PR TITLE
Fix node.js 18deprecation

### DIFF
--- a/.github/workflows/gtest-ci.yml
+++ b/.github/workflows/gtest-ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
actions/checkout@v3 use node.js version 18 (deprecated)=> switch to v4 , use version node.js version 20