### PR TITLE
update Gtest requirements

### DIFF
--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -1,5 +1,5 @@
 project(gmock CXX C)
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
 find_package(gtest_vendor REQUIRED)
 
@@ -13,7 +13,7 @@ include_directories(
 add_library(gmock STATIC
   ${gtest_vendor_BASE_DIR}/src/gtest-all.cc
   src/gmock-all.cc)
-target_compile_features(gmock PUBLIC cxx_std_11)  # Require C++11
+target_compile_features(gmock PUBLIC cxx_std_17)  # Require C++17
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
@@ -31,4 +31,4 @@ if(NOT WIN32)
 endif()
 
 add_library(gmock_main STATIC src/gmock_main.cc)
-target_compile_features(gmock_main PUBLIC cxx_std_11)  # Require C++11
+target_compile_features(gmock_main PUBLIC cxx_std_17)  # Require C++17

--- a/googlemock/CMakeLists.txt.upstream
+++ b/googlemock/CMakeLists.txt.upstream
@@ -35,14 +35,11 @@ endif()
 # CMake files in this project can refer to the root source directory
 # as ${gmock_SOURCE_DIR} and to the root binary directory as
 # ${gmock_BINARY_DIR}.
-# Language "C" is required for find_package(Threads).
-if (CMAKE_VERSION VERSION_LESS 3.0)
-  project(gmock CXX C)
-else()
+
   cmake_policy(SET CMP0048 NEW)
   project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -1,5 +1,5 @@
 project(gtest CXX C)
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
 include_directories(
   include
@@ -7,7 +7,7 @@ include_directories(
 )
 
 add_library(gtest STATIC src/gtest-all.cc)
-target_compile_features(gtest PUBLIC cxx_std_11)  # Require C++11
+target_compile_features(gtest PUBLIC cxx_std_17)  # Require C++17
 
 # When building with asan (i.e. using colcon build --mixin asan-gcc),
 # asan itself provides a "fake" pthread that tricks the pthread
@@ -25,4 +25,4 @@ if(NOT WIN32)
 endif()
 
 add_library(gtest_main STATIC src/gtest_main.cc)
-target_compile_features(gtest_main PUBLIC cxx_std_11)  # Require C++11
+target_compile_features(gtest_main PUBLIC cxx_std_17)  # Require C++17

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -195,7 +195,7 @@ function(cxx_library_with_type name type cxx_flags)
     target_link_libraries(${name} PUBLIC Threads::Threads)
   endif()
 
-  target_compile_features(${name} PUBLIC cxx_std_14)
+  target_compile_features(${name} PUBLIC cxx_std_17)
 endfunction()
 
 ########################################################################


### PR DESCRIPTION
Googletest  v.1.14 require cmake 3.15
also require cxx standard >=14.
ros Rolling requirement is c++17