### PR TITLE
Update googletest_deps.bzl

### DIFF
--- a/.github/workflows/gtest-ci.yml
+++ b/.github/workflows/gtest-ci.yml
@@ -5,39 +5,39 @@ on:
   pull_request:
 
 env:
-  BAZEL_CXXOPTS: -std=c++14
+  BAZEL_CXXOPTS: -std=c++17
 
 jobs:
   Linux:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Tests
-      run: bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
+      run: bazel test --cxxopt=-std=c++17 --features=external_include_paths --test_output=errors ...
 
   macOS:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Tests
-      run:  bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
+      run:  bazel test --cxxopt=-std=c++17 --features=external_include_paths --test_output=errors ...
 
 
   Windows:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Tests
-      run: bazel test --cxxopt=/std:c++14 --features=external_include_paths --test_output=errors ...
+      run: bazel test --cxxopt=/std:c++17 --features=external_include_paths --test_output=errors ...

--- a/googletest_deps.bzl
+++ b/googletest_deps.bzl
@@ -20,3 +20,13 @@ def googletest_deps():
             strip_prefix = "abseil-cpp-20250127",
             urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20250127.1.zip"],
         )
+
+ git_repository(
+  name = "rules_python",
+  tag = "1.3.0",
+  remote = "https://github.com/bazelbuild/rules_python.git",
+)
+
+# if missing it will trig the error message of the OP
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()

--- a/googletest_deps.bzl
+++ b/googletest_deps.bzl
@@ -8,15 +8,15 @@ def googletest_deps():
     if not native.existing_rule("com_googlesource_code_re2"):
         http_archive(
             name = "com_googlesource_code_re2",  # 2023-03-17T11:36:51Z
-            sha256 = "cb8b5312a65f2598954545a76e8bce913f35fbb3a21a5c88797a4448e9f9b9d9",
-            strip_prefix = "re2-578843a516fd1da7084ae46209a75f3613b6065e",
-            urls = ["https://github.com/google/re2/archive/578843a516fd1da7084ae46209a75f3613b6065e.zip"],
+            sha256 = "a835fe55fbdcd8e80f38584ab22d0840662c67f2feb36bd679402da9641dc71e",
+            strip_prefix = "re2-2024-07-02",
+            urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
         )
 
     if not native.existing_rule("com_google_absl"):
         http_archive(
-            name = "com_google_absl",  # 2023-08-01T14:59:13Z
-            sha256 = "d2c09bf3b3aba57ad87a56082020bee2948445407756e92ddaf3595396086853",
-            strip_prefix = "abseil-cpp-22091f4c0d6626b3ef40446ce3d4ccab19425ca3",
-            urls = ["https://github.com/abseil/abseil-cpp/archive/22091f4c0d6626b3ef40446ce3d4ccab19425ca3.zip"],
+            name = "com_google_absl",  #  2025-01-27
+            sha256 = "c51713a5346679e5c3def73a4d683ff64aca5558261d92a9d1f062923b41da9c",
+            strip_prefix = "abseil-cpp-20250127",
+            urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20250127.1.zip"],
         )


### PR DESCRIPTION
updated bazel  external libs
now bazel 8 is supported

https://github.com/abseil/abseil-cpp/releases/tag/20250127.1

https://github.com/google/re2/compare/2024-07-01...2024-07-02