### PR TITLE
Bump `cmake_minimum_required` to 3.10

### DIFF
--- a/googlemock/CMakeLists.txt.install
+++ b/googlemock/CMakeLists.txt.install
@@ -1,5 +1,5 @@
 project(gmock CXX C)
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(gtest_vendor REQUIRED)
 

--- a/googletest/CMakeLists.txt.install
+++ b/googletest/CMakeLists.txt.install
@@ -1,5 +1,5 @@
 project(gtest CXX C)
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 
 include_directories(
   include


### PR DESCRIPTION
### Description

Since cmake 3.31 per https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html there are deprecation warnings for `cmake_minimum_required` < 3.10. The cmake version available on Resolute is 4.1.1.

Build reference: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=27771)](https://ci.ros2.org/job/ci_linux/27771/)