### PR TITLE
Deprecate gtest_vendor and gmock_vendor

### DIFF
--- a/googlemock/package.xml
+++ b/googlemock/package.xml
@@ -28,5 +28,6 @@
 
   <export>
     <build_type>cmake</build_type>
+    <deprecated>Use the rosdep key libgmock-dev instead</deprecated>
   </export>
 </package>

--- a/googletest/package.xml
+++ b/googletest/package.xml
@@ -49,5 +49,6 @@
 
   <export>
     <build_type>cmake</build_type>
+    <deprecated>Use the rosdep key libgtest-dev instead</deprecated>
   </export>
 </package>


### PR DESCRIPTION
Fixes https://github.com/ament/googletest/issues/37

I need to make one more PR to update `ament_cmake_gtest`